### PR TITLE
Apply depends_on fix by Elvar to Ólis fix branch

### DIFF
--- a/modules/cloudwatch-logs/main.tf
+++ b/modules/cloudwatch-logs/main.tf
@@ -62,6 +62,13 @@ module "lambda" {
 }
 
 resource "aws_cloudwatch_log_subscription_filter" "this" {
+  
+  # The depends_on is required here for the allowed_triggers in the above
+  # lambda module, which create aws_lambda_permission resources that are
+  # prerequisite for these aws_cloudwatch_log_subscription_filter resources, to
+  # finish applying before these start.
+  depends_on      = [ module.lambda ]
+
   count           = length(var.log_groups)
   name            = "${module.lambda.lambda_function_name}-Subscription-${count.index}"
   log_group_name  = data.aws_cloudwatch_log_group.this[count.index].name


### PR DESCRIPTION
After running into problems with using the Coralogix cloudwatch module, @aquarhead pointed me toward a fix that Elvar had already made (and created a PR to the upstream module: https://github.com/coralogix/terraform-coralogix-aws/pull/8).

As I want to have both that fix and Ólis' fix (although I'm not really quite sure what that is actually fixing... I was just told that it would be better to have that), I've created my own fork that contains both fixes. I'll be using that until both fixes are merged into the upstream Coralogix module.